### PR TITLE
Use Snyk to scan Docker images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,17 +24,29 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Build the Docker image
+        run: docker build . --file Dockerfile --tag $IMAGE_TAG
+
       - uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build the Docker image
-        run: docker build . --file Dockerfile --tag $IMAGE_TAG
-
       - name: Push to GitHub Container Registry
         run: docker push $IMAGE_TAG
+
+  security_scan:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scan the Docker image
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: ${{ env.IMAGE_TAG }}
+
 
   test_github_action_viability:
     needs: [build]

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,8 +19,12 @@ jobs:
         run: docker build --no-cache --pull . --tag $IMAGE_NAME
       - name: Docker login
         run: echo $DOCKER_HUB_PASSWORD | docker login --username $DOCKER_HUB_USERNAME --password-stdin
-      - name: Docker scan
-        run: docker scan $IMAGE_NAME -f Dockerfile
+      - name: Scan the Docker image
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: ${{ env.IMAGE_NAME }}
 
       # main
       - name: Tag the image as edge

--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -16,5 +16,9 @@ jobs:
         run: echo $DOCKER_HUB_PASSWORD | docker login --username $DOCKER_HUB_USERNAME --password-stdin
       - name: Pull latest image
         run: docker pull $IMAGE_TAG
-      - name: Docker scan
-        run: docker scan $IMAGE_TAG -f Dockerfile
+      - name: Scan the Docker image
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: ${{ env.IMAGE_TAG }}


### PR DESCRIPTION
`docker scan` is not available in GitHub runners.  `docker scan` uses Snyk anyway, so I will just configure that integration.